### PR TITLE
Allow use within isomorphic React applications (SSR).

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import Odometer from 'odometer';
 
 export default class ReactOdometer extends Component {
   static propTypes = {
@@ -10,6 +9,7 @@ export default class ReactOdometer extends Component {
   };
 
   componentDidMount() {
+    const Odometer = require('odometer');
     this.odometer = new Odometer({
       el: ReactDOM.findDOMNode(this),
       value: this.props.value,


### PR DESCRIPTION
Replacing the `import` with a `require` inside `componentDidMount` allows the use of this component within isomorphic React applications.

Without this change, server-side rendering fails as odometerjs depends on various DOM objects and functions (which aren't available in NodeJS).
